### PR TITLE
One-time events 

### DIFF
--- a/socket-io.service.ts
+++ b/socket-io.service.ts
@@ -58,5 +58,9 @@ export class WrappedSocket {
             };
         }).share();
     }
-
+   
+    /* Creates a Promise for a one-time event */
+    fromEventOnce<T>(eventName: string): Promise<T> {
+        return new Promise<T>(resolve => this.once(eventName, resolve));
+    }
 }


### PR DESCRIPTION
Adding fromEventOnce(eventName) method to the socket service, to support one-time events and async/await operations.

e.g.

async () => {
   const response = await this.socket.fromEventOnce("getResponse");
   console.log(response);
}