### PR TITLE
Removed @Injectable decorator to resolve warning message for Angular 5.x

### DIFF
--- a/socket-io.service.ts
+++ b/socket-io.service.ts
@@ -7,7 +7,6 @@ import * as io from 'socket.io-client';
 import { SocketIoConfig } from './socketIoConfig';
 import { SOCKET_CONFIG_TOKEN } from './socket-io.module';
 
-@Injectable()
 export class WrappedSocket {
     subscribersCounter = 0;
     ioSocket: any;


### PR DESCRIPTION
I recently created an issue ticket on the "Warning: Can't resolve all parameters for WrappedSocket in (some service). This will become an error in Angular v5.x". The @Injectable decorator isn't strictly necessary in Angular if the the class (WrappedSocket) has other decorators or no dependencies. By removing it, the error message disappears.

[Error Message Image](https://i.imgur.com/w5K4Unn.png)

Forgot to add that the statement
`constructor(@Inject(SOCKET_CONFIG_TOKEN) config: SocketIoConfig)`
already uses the @Inject decorator. The reason that the arguments could not be resolved is that @Injectable could be inserting unnecessary metadata (clarify me if I'm incorrect), therefore interfering with the dependency injection process.

After removing @Injectable, socket.io works fine when tested and utilized within a program.